### PR TITLE
Descriptive statistics

### DIFF
--- a/SignalAnalysis.UnitTest/StatisticsTest.cs
+++ b/SignalAnalysis.UnitTest/StatisticsTest.cs
@@ -62,13 +62,13 @@ public class StatisticsTest
         Assert.AreEqual(3682913, Statistics.Descriptive.Sum(dataPrimes_1000), 1e-1);
         stopwatch.Stop();
         TimeSpan elapsed = stopwatch.Elapsed;
-        Debug.WriteLine($"Elapsed time - Sum: {elapsed.Hours} hours, {elapsed.Minutes} minutes, {elapsed.Seconds} seconds, and {elapsed.Milliseconds} milliseconds");
-        
+        Debug.WriteLine($"Elapsed time - Sum: {elapsed.Hours} hours, {elapsed.Minutes} minutes, {elapsed.Seconds} seconds, {elapsed.Milliseconds} milliseconds, and {elapsed.Microseconds} microseconds");
+
         stopwatch.Start();
         Assert.AreEqual(3682913, Statistics.Descriptive.SumParallel(dataPrimes_1000), 1e-1);
         stopwatch.Stop();
         elapsed = stopwatch.Elapsed;
-        Debug.WriteLine($"Elapsed time - SumParallel: {elapsed.Hours} hours, {elapsed.Minutes} minutes, {elapsed.Seconds} seconds, and {elapsed.Milliseconds} milliseconds");
+        Debug.WriteLine($"Elapsed time - SumParallel: {elapsed.Hours} hours, {elapsed.Minutes} minutes, {elapsed.Seconds} seconds, {elapsed.Milliseconds} milliseconds, and {elapsed.Microseconds} microseconds");
     }
 
     [TestMethod]

--- a/SignalAnalysis/Statistics.cs
+++ b/SignalAnalysis/Statistics.cs
@@ -71,6 +71,10 @@ public static class Descriptive
             },
             // Combine all local states
             localFinally: (localTotal) => { sum += localTotal; });
+        
+        for (int i = numLoops*processorCount; i<values.Length; i++)
+            sum += values[i];
+
         return sum;
     }
 


### PR DESCRIPTION
Improve internal code for descriptive statistics.
Start writing owner code and avoid LINQ dependencies.