### PR TITLE
Preserve and restore language override setting

### DIFF
--- a/SignalAnalysis.WinUI/Models/EluxDto.cs
+++ b/SignalAnalysis.WinUI/Models/EluxDto.cs
@@ -76,6 +76,8 @@ internal class EluxlDto: DocumentBase
         double sampleFreq;
         string[] seriesLabels;
 
+        var primaryLanguage = Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride;
+
         try
         {
 
@@ -233,7 +235,11 @@ internal class EluxlDto: DocumentBase
             //        MessageBoxIcon.Error);
             //}
         }
-
+        finally
+        {
+            // Restore the original primary language override
+            Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = primaryLanguage;
+        }
         return dto;
     }
 


### PR DESCRIPTION
Save the original ApplicationLanguages.PrimaryLanguageOverride before processing and restore it in a finally block to ensure the application's language setting remains unchanged after execution, even if exceptions occur.